### PR TITLE
Install to themes/carbon-gtk instead of themes/Carbon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.2)
 project(gtkcss)
 
-install(DIRECTORY theme DESTINATION ${CMAKE_INSTALL_PREFIX}/share/themes/Carbon/gtk-3.0)
+install(DIRECTORY theme DESTINATION ${CMAKE_INSTALL_PREFIX}/share/themes/carbon-gtk/gtk-3.0)


### PR DESCRIPTION
Consistency in packaging across editions.
